### PR TITLE
Removed comment about IsStandard for P2SH scripts

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -23,9 +23,6 @@
      * 2. P2SH scripts with a crazy number of expensive
      *    CHECKSIG/CHECKMULTISIG operations
      *
-     * Check transaction inputs, and make sure any
-     * pay-to-script-hash transactions are evaluating IsStandard scripts
-     * 
      * Why bother? To avoid denial-of-service attacks; an attacker
      * can submit a standard HASH... OP_EQUAL transaction,
      * which will get accepted into blocks. The redemption


### PR DESCRIPTION
Since #4365 (62599373883a66a958136f48ab0e2b826e3d5bf8) P2SH scripts do not have to be IsStandard scripts.
